### PR TITLE
fixed msg reply loss in signalingclient

### DIFF
--- a/RoomClient/service/signaling_client.cpp
+++ b/RoomClient/service/signaling_client.cpp
@@ -73,12 +73,12 @@ void SignalingClient::send(const std::string& text, int64_t transcation, Success
         request->setText(text);
         request->setResolveCallback(scb);
         request->setRejectCallback(fcb);
-        _transport->send(request->text());
-        request->ticktock();
         {
             std::lock_guard<std::mutex> locker(_requestMutex);
             _requestMap[request->id()] = request;
         }
+        _transport->send(request->text());
+        request->ticktock();
     }
 }
 
@@ -90,12 +90,12 @@ void SignalingClient::send(const std::vector<uint8_t>& data, int64_t transcation
         request->setData(data);
         request->setResolveCallback(scb);
         request->setRejectCallback(fcb);
-        _transport->send(request->data());
-        request->ticktock();
         {
             std::lock_guard<std::mutex> locker(_requestMutex);
             _requestMap[request->id()] = request;
         }
+        _transport->send(request->data());
+        request->ticktock();
     }
 }
 

--- a/RoomClient/service/signaling_client.cpp
+++ b/RoomClient/service/signaling_client.cpp
@@ -68,6 +68,11 @@ void SignalingClient::disconnect()
 void SignalingClient::send(const std::string& text, int64_t transcation, SuccessCallback scb, FailureCallback fcb)
 {
     if (!text.empty()) {
+        // Handle response sned directly
+        if (scb == nullptr && fcb == nullptr) {
+            _transport->send(text);
+            return;
+        }
         uint32_t timeout = 1500 * (15 + (0.1 * _requestMap.size()));
         auto request = std::make_shared<vi::WebsocketRequest>(transcation, timeout);
         request->setText(text);
@@ -85,6 +90,11 @@ void SignalingClient::send(const std::string& text, int64_t transcation, Success
 void SignalingClient::send(const std::vector<uint8_t>& data, int64_t transcation, SuccessCallback scb, FailureCallback fcb)
 {
     if (!data.empty()) {
+        // Handle response sned directly
+        if (scb == nullptr && fcb == nullptr) {
+            _transport->send(data);
+            return;
+        }
         uint32_t timeout = 1500 * (15 + (0.1 * _requestMap.size()));
         auto request = std::make_shared<vi::WebsocketRequest>(transcation, timeout);
         request->setData(data);


### PR DESCRIPTION
Solve the occasional stuck problem when entering and exiting the room frequently
mainly because the reply to the message is lost and not handled correctly

解决在频繁进出房间时偶现的卡死问题 主要是消息的回复丢失未被正确处理