### PR TITLE
解决Q_EMIT draw(videeoFrame) 没有触发槽函数问题。

### DIFF
--- a/App/main.cpp
+++ b/App/main.cpp
@@ -23,6 +23,7 @@ static void registerMetaTypes()
     qRegisterMetaType<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>>("rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>");
     qRegisterMetaType<std::shared_ptr<vi::IParticipant>>("std::shared_ptr<vi::IParticipant>");
     qRegisterMetaType<webrtc::VideoFrame*>("const webrtc::VideoFrame*");
+    qRegisterMetaType<std::shared_ptr<webrtc::VideoFrame>>("std::shared_ptr<webrtc::VideoFrame>");
 }
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
因为没有注册格式。导致槽函数触发失败。最终导致画面无法显示问题。见 https://github.com/ouxianghui/mediasoup-client/issues/18